### PR TITLE
Create enough space on LUNs now we're not double allocating(!)

### DIFF
--- a/scripts/infra/add_lun.py
+++ b/scripts/infra/add_lun.py
@@ -3,8 +3,8 @@
 import rtslib
 
 iscsi = rtslib.FabricModule("iscsi")
-f = rtslib.FileIOStorageObject("test1", "/tmp/test.img", 10000000000)
-f2 = rtslib.FileIOStorageObject("test2", "/tmp/test2.img", 10000000000)
+f = rtslib.FileIOStorageObject("test1", "/tmp/test.img", 20000000000)
+f2 = rtslib.FileIOStorageObject("test2", "/tmp/test2.img", 20000000000)
 target = rtslib.Target(iscsi)
 tpg = rtslib.TPG(target,1)
 tpg.enable = True


### PR DESCRIPTION
The LUNs exposed were only 9.31GB (10000000000B) and we were creating a 10GB
VDI and filling it. This probably should have been an alarm bell that it was
deemed to be working.

However, now we've stopped double allocating blocks (by
https://github.com/xapi-project/xenvm/pull/136), we don't have enough space to
run the test (as we should expect).

This patch makes the LUNs just short of 20GB.

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>