### PR TITLE
Self destruct ocamlscript executables

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,6 +22,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         inline: "hostname host#{i}; echo host#{i} > /etc/hostname"
       host.vm.synced_folder "xs/rpms", "/rpms", type: "rsync", rsync__args: ["--verbose", "--archive", "-z", "--copy-links"]
       host.vm.synced_folder "xs/opt", "/opt", type: "rsync", rsync__args: ["--verbose", "--archive", "-z", "--copy-links"]
+      host.vm.synced_folder "xs/sbin", "/sbin", type: "rsync", rsync__args: ["--verbose", "--archive", "-z", "--copy-links"]
+      host.vm.synced_folder "xs/bin", "/bin", type: "rsync", rsync__args: ["--verbose", "--archive", "-z", "--copy-links"]
       host.vm.synced_folder "scripts/xs", "/scripts", type: "rsync", rsync__args: ["--verbose", "--archive", "-z", "--copy-links"]
 
       host.vm.provision "shell", path: "scripts/xs/update.sh"

--- a/tests/test_common.ml
+++ b/tests/test_common.ml
@@ -203,3 +203,19 @@ let get_control_domain state host =
     (fun (vm_ref, vm_rec) ->
        vm_rec.API.vM_resident_on=host && vm_rec.API.vM_is_control_domain)
     vms |> fst |> Lwt.return
+
+let run_and_self_destruct (t : 'a Lwt.t) : 'a =
+  let t' =
+    Lwt.finalize (fun () -> t) (fun () ->
+      let name = Sys.argv.(0) in
+      let ocamlscript_exe =
+        if Filename.check_suffix name "exe" then name else name ^ ".exe" in
+      if (try Unix.(access ocamlscript_exe [ F_OK ]); true with _ -> false)
+      then
+        Lwt_io.printlf "Unlinking ocamlscript compilation: %s" ocamlscript_exe
+        >>= fun () ->
+        Lwt_unix.unlink ocamlscript_exe
+      else return ()
+    )
+  in
+  Lwt_main.run t'

--- a/tests/test_quicktest
+++ b/tests/test_quicktest
@@ -28,12 +28,8 @@ let _ =
     Printf.printf "Quicktest has run!\n%!";
     Lwt.return ()
   in
-  Lwt_main.run th;
+  run_and_self_destruct th;
 
 (* Local Variables: *)
 (* mode: tuareg *)
 (* End: *)
-  
-
-
-

--- a/tests/test_thin_lvhd
+++ b/tests/test_thin_lvhd
@@ -83,12 +83,8 @@ let _ =
     >>= fun () ->
     Lwt.return ()
   in
-  Lwt_main.run th;
+  run_and_self_destruct th;
 
 (* Local Variables: *)
 (* mode: tuareg *)
 (* End: *)
-  
-
-
-


### PR DESCRIPTION
Changing a module that the script depends on does not cause recompilation of
the OCamlscript script. This is a known issue with OCamlscript[1] and this
patch works around this by unlinking the auto-generated binary after it has
finished executing its main Lwt thread.

[1]: https://github.com/mjambon/ocamlscript/issues/2

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>