### PR TITLE
test_thin_lvhd: Use autodetect for with_vdi

### DIFF
--- a/tests/test_thin_lvhd
+++ b/tests/test_thin_lvhd
@@ -15,7 +15,7 @@ let with_vdi rpc session_id state vdi f =
   let master = state.master in
   get_control_domain state master
   >>= fun vm ->
-  VBD.create ~rpc ~session_id ~vM:vm ~vDI:vdi ~userdevice:"0" ~bootable:false
+  VBD.create ~rpc ~session_id ~vM:vm ~vDI:vdi ~userdevice:"autodetect" ~bootable:false
     ~mode:`RW ~_type:`Disk ~unpluggable:true ~empty:false ~other_config:[]
     ~qos_algorithm_type:"" ~qos_algorithm_params:[]
   >>= fun vbd ->


### PR DESCRIPTION
We can't assume that device 0 will be free for dom0. In fact, when SR stats are
enabled there's a good chance it won't be because of the asynchronous stats
push/pulling from a VDI.

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>