### PR TITLE
fix ansible errors and generalize creation N hosts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,14 +44,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       host.vm.box = "jonludlam/feature-qemu-datapath"
       host.vm.network "public_network", bridge: "xenbr0"
       host.vm.synced_folder "scripts", "/scripts", type:"rsync", rsync__args: ["--verbose", "--archive", "-z", "--copy-links"]
-      host.vm.provision :ansible do |ansible|
-        ansible.groups = {
-          "cluster" => (1..N).map{|i| "cluster#{i}"},
-          "infrastructure" => ["infrastructure"]
-        }
-        ansible.limit = "cluster"
+      if i == N
+          host.vm.provision :ansible do |ansible|
+            ansible.groups = {
+              "cluster" => (1..N).map{|i| "cluster#{i}"},
+              "infrastructure" => ["infrastructure"]
+            }
+            ansible.limit = "cluster"
 #        ansible.verbose = "vvv"
-        ansible.playbook = "playbook.yml"
+            ansible.playbook = "playbook.yml"
+          end
       end
     end
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,14 +38,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
 # Defines cluster{1,2,3} for corosync investigation
-  (1..3).each do |i|
+  N = 3
+  (1..N).each do |i|
     config.vm.define "cluster#{i}" do |host|
       host.vm.box = "jonludlam/feature-qemu-datapath"
       host.vm.network "public_network", bridge: "xenbr0"
-      host.vm.synced_folder "scripts", "/scripts", type:"rsync", rsync__args: ["--verbose", "--archive", "-z", "--copy-links"] 
+      host.vm.synced_folder "scripts", "/scripts", type:"rsync", rsync__args: ["--verbose", "--archive", "-z", "--copy-links"]
       host.vm.provision :ansible do |ansible|
         ansible.groups = {
-          "cluster" => ["cluster1", "cluster2", "cluster3"],
+          "cluster" => (1..N).map{|i| "cluster#{i}"},
           "infrastructure" => ["infrastructure"]
         }
         ansible.limit = "cluster"

--- a/playbook.yml
+++ b/playbook.yml
@@ -28,9 +28,9 @@
       systemd: name="{{ item }}" state=started enabled=yes
       with_items:
         - pcsd
-    - name: Build hosts file
-      lineinfile: dest=/etc/hosts regexp='.*{{ item }}$' line="{{ hostvars[item].ansible_default_ipv4.address }} {{item}}" state=present
-      when: hostvars[item].ansible_default_ipv4.address is defined
-      with_items: "{{ groups['all'] }}"
     - name: Create hostvars dump
       action: template src=templates/checkvars.j2 dest=/tmp/ansible.vars
+    - name: Build hosts file
+      lineinfile: dest=/etc/hosts regexp='.*{{ item }}$' line="{{ hostvars[item].ansible_default_ipv4.address }} {{item}}" state=present
+      when: hostvars[item].ansible_default_ipv4 is defined and hostvars[item].ansible_default_ipv4.address is defined
+      with_items: "{{ groups['all'] }}"

--- a/tests/setup_cluster.sh
+++ b/tests/setup_cluster.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e
 vagrant up cluster{1,2,3}
 
 

--- a/tests/setup_cluster.sh
+++ b/tests/setup_cluster.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
-vagrant up cluster{1,2,3}
+vagrant up cluster{1,2,3} --no-provision
+vagrant provision cluster{1,2,3}
 
 
 echo "Cluster auth"


### PR DESCRIPTION
You can now run this sequence without getting vagrant/ansible errors, and without to having to rerun the commands all the time:
```
$ vagrant destroy cluster{1,2,3}
$ tests/setup_cluster.sh
```

This still needs my hack for Vagrant's SSH to cope with `nc` reporting `EPIPE` and treat it as a retriable error though: `sudo sed -i -e 's/rescue Errno::ETIMEDOUT/\0,Errno::EPIPE/' /opt/vagrant/embedded/gems/gems/vagrant-1.9.6/plugins/communicators/ssh/communicator.rb` 
