### PR TITLE
Make provisioning persistent across reboots, setup SBD/DLM, explain `pcs cluster setup`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,7 +48,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           host.vm.provision :ansible do |ansible|
             ansible.groups = {
               "cluster" => (1..N).map{|i| "cluster#{i}"},
-              "infrastructure" => ["infrastructure"]
+              "infra" => ["infrastructure"]
             }
             ansible.limit = "cluster"
 #        ansible.verbose = "vvv"

--- a/playbook.yml
+++ b/playbook.yml
@@ -80,6 +80,14 @@
       systemd: name="{{ item }}" state=started enabled=yes
       with_items:
         - pcsd
+
+    - meta: flush_handlers # run all handlers, e.g. if initiatorname was changed
+    - name: setup local iSCSI
+      open_iscsi:
+        portal: "{{hostvars['infrastructure'].ansible_ssh_host}}"
+        login: yes
+        discover: yes
+        show_nodes: yes
   handlers:
       - name: save iptables
         command: service iptables save

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,5 +1,21 @@
 ---
-- hosts: all
+# Need to setup networking as a separate play, otherwise ansible_default_ipv4 stays unset
+- hosts: cluster
+  become: true
+  become_method: sudo
+  remote_user: root
+  tasks:
+    - name: set eth1 to dhcp
+      copy:
+        content: |
+          DEVICE=eth1
+          BOOTPROTO=dhcp
+          ONBOOT=yes
+        dest: /etc/sysconfig/network-scripts/ifcfg-eth1
+    - name: bring eth1 up
+      command: ifup eth1
+      when: not (ansible_eth1.ipv4 is defined and ansible_eth1.ipv4.address is defined)
+- hosts: cluster
   become: true
   become_method: sudo
   become_user: root
@@ -8,9 +24,6 @@
       shell: |
        hostname "{{inventory_hostname}}"
        echo "{{inventory_hostname}}" > /etc/hostname
-    - name: dhcp eth1
-      shell: |
-        ip addr show dev eth1 primary | grep inet || dhclient eth1
     - name: install pacemaker stuff
       yum: name="{{ item }}" state=latest enablerepo=base
       with_items:

--- a/playbook.yml
+++ b/playbook.yml
@@ -20,30 +20,68 @@
   become_method: sudo
   become_user: root
   tasks:
+    # set unique values-
+    - name: Create hostvars dump
+      action: template src=templates/checkvars.j2 dest=/tmp/ansible.var
     - name: set hostname
       shell: |
        hostname "{{inventory_hostname}}"
        echo "{{inventory_hostname}}" > /etc/hostname
+      when: ansible_hostname != inventory_hostname
+    - name: read iSCSI initiator name
+      command: cat /etc/iscsi/initiatorname.iscsi
+      register: iscsi_initiator
+    - name: set unique iSCSI initiator name
+      shell: echo "InitiatorName=$(/sbin/iscsi-iname)" >/etc/iscsi/initiatorname.iscsi
+      when: iscsi_initiator == "InitiatorName=iqn.1994-05.com.redhat:a0b68f6592ea"
+      notify: restart iscsid
+
+    # create shared config files
+    - name: Build hosts file
+      lineinfile: dest=/etc/hosts regexp='.*{{ item }}$' line="{{ hostvars[item].ansible_default_ipv4.address }} {{item}}" state=present
+      when: hostvars[item].ansible_default_ipv4 is defined and hostvars[item].ansible_default_ipv4.address is defined
+      with_items: "{{ groups['all'] }}"
+
+    # Note: if upgrading a live system would need to stop the cluster or at least disable fencing first
     - name: install pacemaker stuff
-      yum: name="{{ item }}" state=latest enablerepo=base
+      yum: name="{{ item }}" state=latest enablerepo=base,updates
       with_items:
+        - corosync
+        - dlm
         - pcs
         - pacemaker
         - fence-agents-all
+        - sbd
+        - iptables-services
+
+    - name: load watchdog module on boot
+      lineinfile:
+        dest: /etc/modules-load.d/watchdog.conf
+        line: xen_wdt
+        state: present
+        create: true
+    - name: load watchdog now
+      modprobe:
+          name: xen_wdt
+          state: present
+
     - name: add hacluster user
       user:
         name: hacluster
         shell: /bin/bash
         password: $6$3Vsv/USdPcUl$ShL19F/R7QcTvgZxvgzLhNRn5Dspme06srj565UiQfYa2Q94or1qCBxjeb1XepAqVdHD7WzWm66CO0cFWFgaE/
+
     - name: Flush firewall
       iptables: flush=true
+      notify:
+        - save iptables
+
     - name: start services
       systemd: name="{{ item }}" state=started enabled=yes
       with_items:
         - pcsd
-    - name: Create hostvars dump
-      action: template src=templates/checkvars.j2 dest=/tmp/ansible.vars
-    - name: Build hosts file
-      lineinfile: dest=/etc/hosts regexp='.*{{ item }}$' line="{{ hostvars[item].ansible_default_ipv4.address }} {{item}}" state=present
-      when: hostvars[item].ansible_default_ipv4 is defined and hostvars[item].ansible_default_ipv4.address is defined
-      with_items: "{{ groups['all'] }}"
+  handlers:
+      - name: save iptables
+        command: service iptables save
+      - name: restart iscsid
+        service: name=iscsid state=restarted

--- a/scripts/raw/cib_crm_config.xml
+++ b/scripts/raw/cib_crm_config.xml
@@ -1,0 +1,5 @@
+<crm_config>
+  <cluster_property_set id="cib-bootstrap-options">
+    <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="freeze"/>
+  </cluster_property_set>
+</crm_config>

--- a/scripts/raw/cib_resources.xml
+++ b/scripts/raw/cib_resources.xml
@@ -1,0 +1,16 @@
+<resources>
+  <clone id="dlm-clone">
+    <primitive class="ocf" id="dlm" provider="pacemaker" type="controld">
+      <instance_attributes id="dlm-instance_attributes"/>
+      <operations>
+        <op id="dlm-start-interval-0s" interval="0s" name="start" timeout="90"/>
+        <op id="dlm-stop-interval-0s" interval="0s" name="stop" timeout="100"/>
+        <op id="dlm-monitor-interval-30s" interval="30s" name="monitor" on-fail="fence"/>
+      </operations>
+    </primitive>
+    <meta_attributes id="dlm-clone-meta_attributes">
+      <nvpair id="dlm-clone-meta_attributes-interleave" name="interleave" value="true"/>
+      <nvpair id="dlm-clone-meta_attributes-ordered" name="ordered" value="true"/>
+    </meta_attributes>
+  </clone>
+</resources>

--- a/scripts/raw/corosync.j2
+++ b/scripts/raw/corosync.j2
@@ -1,0 +1,26 @@
+totem {
+    version: 2
+    secauth: off
+    cluster_name: {{ cluster_name }}
+    transport: udpu
+}
+
+nodelist {
+    {% for host in groups['all'] %}
+    node {
+        ring0_addr: {{ host }}
+        nodeid: {{ loop.index }}
+    }
+    {% endfor %}
+}
+
+quorum {
+    provider: corosync_votequorum
+    auto_tie_breaker: 1
+}
+
+logging {
+    to_logfile: yes
+    logfile: /var/log/cluster/corosync.log
+    to_syslog: yes
+}

--- a/scripts/setup_raw
+++ b/scripts/setup_raw
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+set -x
+
+echo "Creating corosync configuration"
+echo "==============================="
+systemctl stop pcsd
+
+cat >/etc/corosync/corosync.conf <<EOF
+totem {
+    version: 2
+    secauth: off
+    cluster_name: cluster
+    transport: udpu
+}
+
+nodelist {
+EOF
+
+i=1
+for host in $*; do
+    i=$(($i+1))
+    cat >>/etc/corosync/corosync.conf <<EOF
+    node {
+        ring0_addr: $host
+        nodeid: $i
+    }
+EOF
+done
+
+cat >>/etc/corosync/corosync.conf <<EOF
+}
+
+quorum {
+    provider: corosync_votequorum
+    auto_tie_breaker: 1
+}
+
+logging {
+    to_logfile: yes
+    logfile: /var/log/cluster/corosync.log
+    to_syslog: yes
+}
+EOF
+
+corosync -t
+
+echo "Starting cluster"
+echo "================"
+systemctl enable corosync pacemaker
+systemctl start corosync pacemaker
+
+# Start pcsd again
+systemctl start pcsd

--- a/tests/setup_cluster.sh
+++ b/tests/setup_cluster.sh
@@ -17,9 +17,12 @@ echo "Cluster setup"
 echo "============="
 
 vagrant ssh cluster1 -c "sudo pcs cluster setup --name cluster $HOSTS"
+vagrant ssh cluster1 -c "sudo pcs stonith sbd enable"
 
 echo "Cluster start"
 echo "============="
 
 vagrant ssh cluster1 -c "sudo pcs cluster enable --all"
 vagrant ssh cluster1 -c "sudo pcs cluster start --all"
+vagrant ssh cluster1 -c "sudo pcs property set no-quorum-policy=freeze"
+vagrant ssh cluster1 -c "sudo pcs resource create dlm ocf:pacemaker:controld op monitor interval=30s on-fail=fence clone interleave=true ordered=true"

--- a/tests/setup_cluster.sh
+++ b/tests/setup_cluster.sh
@@ -16,7 +16,7 @@ vagrant ssh cluster1 -c "sudo pcs cluster auth -u hacluster -p mysecurepassword 
 echo "Cluster setup"
 echo "============="
 
-vagrant ssh cluster1 -c "sudo pcs cluster setup --name cluster $HOSTS"
+vagrant ssh cluster1 -c "sudo pcs cluster setup --name cluster $HOSTS --auto_tie_breaker=1"
 vagrant ssh cluster1 -c "sudo pcs stonith sbd enable"
 
 echo "Cluster start"

--- a/tests/setup_cluster.sh
+++ b/tests/setup_cluster.sh
@@ -3,6 +3,8 @@ set -e
 vagrant up cluster{1,2,3} --no-provision
 vagrant provision cluster{1,2,3}
 
+# workaround NilClass exception
+vagrant up infrastructure || vagrant up infrastructure
 
 echo "Cluster auth"
 echo "============"

--- a/tests/setup_cluster.sh
+++ b/tests/setup_cluster.sh
@@ -1,26 +1,25 @@
 #!/bin/bash
+set -x
 set -e
-vagrant up cluster{1,2,3} --no-provision
-vagrant provision cluster{1,2,3}
 
 # workaround NilClass exception
 vagrant up infrastructure || vagrant up infrastructure
 
+HOSTS=$(vagrant status |  grep ^cluster |cut -f1 -d' '|xargs echo)
+vagrant up $HOSTS
+echo $HOSTS
+
 echo "Cluster auth"
 echo "============"
-
-vagrant ssh cluster1 -c "sudo pcs cluster auth -u hacluster -p mysecurepassword cluster1 cluster2 cluster3"
-
+vagrant ssh cluster1 -c "sudo pcs cluster auth -u hacluster -p mysecurepassword $HOSTS"
 
 echo "Cluster setup"
 echo "============="
 
-vagrant ssh cluster1 -c "sudo pcs cluster setup --name cluster cluster1 cluster2 cluster3"
-
+vagrant ssh cluster1 -c "sudo pcs cluster setup --name cluster $HOSTS"
 
 echo "Cluster start"
 echo "============="
 
+vagrant ssh cluster1 -c "sudo pcs cluster enable --all"
 vagrant ssh cluster1 -c "sudo pcs cluster start --all"
-
-

--- a/tests/setup_raw_cluster.sh
+++ b/tests/setup_raw_cluster.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -x
+set -e
+
+# workaround NilClass exception
+vagrant up infrastructure || vagrant up infrastructure
+
+HOSTS=$(vagrant status |  grep ^cluster |cut -f1 -d' '|xargs echo)
+vagrant up $HOSTS
+echo $HOSTS
+# vagrant rsync $HOSTS
+
+echo "Cluster auth"
+echo "============"
+vagrant ssh cluster1 -c "sudo pcs cluster auth -u hacluster -p mysecurepassword $HOSTS"
+
+
+for host in $HOSTS; do
+    vagrant ssh $host -c "sudo /scripts/setup_raw $HOSTS"
+done
+
+
+echo "Updating cluster properties"
+echo "==========================="
+vagrant ssh cluster1 -c "\
+sudo cibadmin --replace -o resources --xml-pipe </scripts/raw/cib_resources.xml &&\
+sudo cibadmin --replace -o crm_config --xml-pipe </scripts/raw/cib_crm_config.xml"
+
+echo "Enabling SBD"
+vagrant ssh cluster1 -c "sudo pcs cluster stop --all"
+vagrant ssh cluster1 -c "sudo pcs stonith sbd enable"
+vagrant ssh cluster1 -c "sudo pcs cluster start --all"
+
+vagrant ssh cluster1 -c "\
+sudo dlm_tool status; \
+sudo corosync-quorumtool; \
+sudo crm_mon -1"


### PR DESCRIPTION
When fencing is enabled it is useful to have a working cluster immediately after reboot without having to reprovision.

There is also a new test: `tests/setup_raw_cluster.sh` that mimics what `pcs cluster setup` does to better understand exactly what config files it creates.