### PR TITLE
Make VM names different from each-other and use one bridge for infrastructure VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     infra.vm.provision "shell", path: "scripts/infra/vagrant_provision.sh"
     infra.vm.synced_folder "scripts/infra", "/scripts", type: "rsync", rsync__args: ["--verbose", "--archive", "-z", "--copy-links"]
     infra.vm.network "public_network", bridge: "xenbr0"
-    infra.vm.network "public_network", bridge: "xenbr1"
     config.vm.provider "xenserver" do |xs|
         xs.name = "#{USER}/infrastructure/#{infra.vm.box}"
     end


### PR DESCRIPTION
Use one bridge to workaround this nilclass exception: https://github.com/jonludlam/vagrant-xenserver/pull/47
Use different names to make it easier to find which VM is cluster1,cluster2,etc in XC.

I didn't make this change for the `honolulu` VMs, should I?