### PR TITLE
common/tasks/main.yml: don't build /etc/hosts file

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -4,12 +4,6 @@
     hostname "{{inventory_hostname}}"
     echo "{{inventory_hostname}}" > /etc/hostname
   when: ansible_hostname != inventory_hostname
-- name: gather facts again
-  setup:
-- name: Build hosts file
-  lineinfile: dest=/etc/hosts regexp='.*{{ item }}$' line="{{ hostvars[item].ansible_default_ipv4.address }} {{item}}" state=present
-  when: hostvars[item].ansible_default_ipv4 is defined and hostvars[item].ansible_default_ipv4.address is defined
-  with_items: "{{ groups['all'] }}"
 - name: Find RPMs
   find:
     paths: "/rpms"


### PR DESCRIPTION
Since dropping pacemaker, we are purely IP-based now, so don't need to build
/etc/hosts.

Signed-off-by: Jonathan Davies <jonathan.davies@citrix.com>