### PR TITLE
[CP-25914] Generate SSL keys in ansible

### DIFF
--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Generate xapissl.pem
+  command: /opt/xensource/libexec/generate_ssl_cert /etc/xensource/xapi-ssl.pem {{inventory_hostname}}
+
 # Note: if upgrading a live system would need to stop the cluster or at least disable fencing first
 - name: Run xapi-clusterd
   systemd: state=started enabled=yes name=xapi-clusterd


### PR DESCRIPTION
- Using libexec/generate_ssl_cert
- Needed so we can use this as the keys file for OpenSSL

Signed-off-by: Callum McIntyre <callum.mcintyre@citrix.com>