### PR TITLE
[CA-280422] Open port 8895 for Testarossa

### DIFF
--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -8,6 +8,15 @@
     regexp: '^ExecStart=/usr/sbin/xapi-clusterd$'
     line: 'ExecStart=/usr/sbin/xapi-clusterd --local_port 2375'
 
+- name: Open port 2375 in the firewall
+  lineinfile:
+    path: /etc/sysconfig/iptables
+    insertafter: '-A RH-Firewall-1-INPUT -p tcp -m tcp --dport 8892 -j ACCEPT'
+    line: '-A RH-Firewall-1-INPUT -p tcp -m tcp --dport 2375 -j ACCEPT'
+
+- name: Restart iptables to pick up the new rule
+  systemd: state=restarted enabled=yes name=iptables
+
 # Note: if upgrading a live system would need to stop the cluster or at least disable fencing first
 - name: Run xapi-clusterd
   systemd: state=started enabled=yes name=xapi-clusterd

--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -6,13 +6,13 @@
   lineinfile:
     path: /usr/lib/systemd/system/xapi-clusterd.service
     regexp: '^ExecStart=/usr/sbin/xapi-clusterd$'
-    line: 'ExecStart=/usr/sbin/xapi-clusterd --local_port 2375'
+    line: 'ExecStart=/usr/sbin/xapi-clusterd --local_port 8895'
 
-- name: Open port 2375 in the firewall
+- name: Open port 8895 in the firewall
   lineinfile:
     path: /etc/sysconfig/iptables
     insertafter: '-A RH-Firewall-1-INPUT -p tcp -m tcp --dport 8892 -j ACCEPT'
-    line: '-A RH-Firewall-1-INPUT -p tcp -m tcp --dport 2375 -j ACCEPT'
+    line: '-A RH-Firewall-1-INPUT -p tcp -m tcp --dport 8895 -j ACCEPT'
 
 - name: Restart iptables to pick up the new rule
   systemd: state=restarted enabled=yes name=iptables


### PR DESCRIPTION
We no longer open port 2375 by default, but our tests do need it (they open the local server there). This commit adds 2 new tasks to the cluster role:

- patch iptables to open port 2375
- restart iptables with a systemd task to pick up the change

Signed-off-by: Callum McIntyre <callum.mcintyre@citrix.com>