### PR TITLE
cluster role: open ports using firewall plugin

### DIFF
--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -7,17 +7,14 @@
 - name: Add local-port to xapi-clusterd service file
   lineinfile:
     path: /usr/lib/systemd/system/xapi-clusterd.service
-    regexp: '^ExecStart=/usr/sbin/xapi-clusterd$'
+    regexp: '^ExecStart=/usr/sbin/xapi-clusterd'
     line: 'ExecStart=/usr/sbin/xapi-clusterd --local_port 8895'
 
-- name: Open port 8895 in the firewall
-  lineinfile:
-    path: /etc/sysconfig/iptables
-    insertafter: '-A RH-Firewall-1-INPUT -p tcp -m tcp --dport 8896 -j ACCEPT'
-    line: '-A RH-Firewall-1-INPUT -p tcp -m tcp --dport 8895 -j ACCEPT'
-
-- name: Restart iptables to pick up the new rule
-  systemd: state=restarted enabled=yes name=iptables
+- name: Open port 8895 and 8896 in the firewall
+  command: "/etc/xapi.d/plugins/firewall-port open {{ item }}"
+  with_items:
+      - 8895
+      - 8896
 
 # Note: if upgrading a live system would need to stop the cluster or at least disable fencing first
 - name: Run xapi-clusterd
@@ -26,7 +23,4 @@
 # We are going to fence in the tests, make sure we don't loose all the
 # provisioning after a reboot
 - name: Sync
-  command: sync
-
-- name: Sync2
   command: sync


### PR DESCRIPTION
We need to open 2 ports now (because the clustering port is open at
 runtime by XAPI, but we have not XAPI here).
Can't rely on how the firewall rules file looked like, so just use the
same script used by XAPI to open them.

Also fix the systemd unit editing rule that added port 8895: the regex
must match the line both before and *after* the modification, otherwise
if you rerun provisioning you end up with multiple copies of the same
line.

Note: unrelated to this PR, but if you are on Ubuntu 18.04 you will need to `gem install xmlrpc --user` to make vagrant-xenserver work again: https://github.com/jonludlam/vagrant-xenserver/issues/54