### PR TITLE
Do not start XAPI in clustering component tests

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
-LOCAL_BRANCH = ENV.fetch("LOCAL_BRANCH", "feature-REQ477-master")
+LOCAL_BRANCH = ENV.fetch("LOCAL_BRANCH", "team-ring3-master")
 
 USER = ENV.fetch("USER")
 folders = {
@@ -83,7 +83,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 #  end
 
 # Defines cluster{1,2,3} for corosync investigation
-  N = 64
+  N = 16
   NAMES = Hash[ (1..N).map{|i| [i, "cluster#{i}"]} ]
   (1..N).each do |i|
     hostname = NAMES[i]

--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -2,6 +2,9 @@
 - name: disable XAPI-NBD path activation
   systemd: enabled=no masked=yes name=xapi-nbd.path
 
+- name: disable ntpdate
+  systemd: enabled=no masked=yes name=ntpdate
+
 - name: Generate xapissl.pem
   command: /opt/xensource/libexec/generate_ssl_cert /etc/xensource/xapi-ssl.pem {{inventory_hostname}}
   args:

--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: disable XAPI-NBD path activation
+  systemd: enabled=no masked=yes name=xapi-nbd.path
+
 - name: Generate xapissl.pem
   command: /opt/xensource/libexec/generate_ssl_cert /etc/xensource/xapi-ssl.pem {{inventory_hostname}}
   args:


### PR DESCRIPTION
Generating a new SSL certificate causes `xapi-nbd` to get started due to
path activation, which also starts xapi and a lot of other daemons.
We want to test clustering in isolation, so do ensure we do not start
xapi-nbd via path activation by masking the service.

Also update the branch, the feature branch got deleted, it is all in
master now.

Change N to 16 to speed up create operations, we do not support beyond
16 yet.