### PR TITLE
CP-28932: do not start xapi-clusterd from ansible

### DIFF
--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -24,7 +24,7 @@
 
 # Note: if upgrading a live system would need to stop the cluster or at least disable fencing first
 - name: Run xapi-clusterd
-  systemd: state=started enabled=yes name=xapi-clusterd
+  systemd: enabled=yes name=xapi-clusterd
 
 # We are going to fence in the tests, make sure we don't loose all the
 # provisioning after a reboot


### PR DESCRIPTION
We are now using snapshots to run the component tests, and reverting to
a snapshot would cause an extra "boot count". (xapi-clusterd counts how many times it was started by appending to a file in `/var/opt/xapi-clusterd/boot-times`).
Have the boot after revert to snapshot be the first "boot" by just
enabling xapi-clusterd without starting it immediately.
