### PR TITLE
Use 2048MiB of memory for nested xenserver

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -134,7 +134,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider "xenserver" do |xs|
     xs.use_himn = true
-    xs.memory = 1024
+    xs.memory = 2048
     xs.xs_host = "gandalf.uk.xensource.com"
     xs.xs_username = "root"
     xs.xs_password = "xenroot"


### PR DESCRIPTION
We use this when installing, and with the latest master dom0 memory is calculated as 1232MiB, which will fail to boot completely if we only give it 1024MiB.