### PR TITLE
CP-30428 don't disable ntpdate in playbook

### DIFF
--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -2,9 +2,6 @@
 - name: disable XAPI-NBD path activation
   systemd: enabled=no masked=yes name=xapi-nbd.path
 
-- name: disable ntpdate
-  systemd: enabled=no masked=yes name=ntpdate
-
 - name: Generate xapissl.pem
   command: /opt/xensource/libexec/generate_ssl_cert /etc/xensource/xapi-ssl.pem {{inventory_hostname}}
   args:


### PR DESCRIPTION
The ansible playbook was failing because it could
not find the ntpdate systemd service.

Signed-off-by: lippirk <ben.anson@citrix.com>